### PR TITLE
Update web-push-sdk code to v7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quasar-app-extension-onesignal",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Onesignal Intergration for Quasar in PWA mode",
   "author": "Mouti'a Benachour",
   "main": "src/index.js",

--- a/src/boot-web.js
+++ b/src/boot-web.js
@@ -28,8 +28,9 @@ export default async ({ app, Vue }) => {
       addScriptTag()
 
       window.OneSignal = window.OneSignal || []
-      window.OneSignal.push(function () {
-        window.OneSignal.init(Object.assign(
+      window.OneSignal.push([
+        'init',
+        Object.assign(
           {
             appId,
             requiresUserPrivacyConsent: true,
@@ -42,17 +43,23 @@ export default async ({ app, Vue }) => {
             }
           },
           initConfig
-        ))
-      })
+        )
+      ])
     },
     optIn (externalUserId) {
       if (!onClient) {
         return
       }
-      window.OneSignal.provideUserConsent(true)
-      window.OneSignal.showNativePrompt()
+      window.OneSignal.push(function () {
+        window.OneSignal.provideUserConsent(true)
+      })
+      window.OneSignal.push(function () {
+        window.OneSignal.showNativePrompt()
+      })
       if (externalUserId) {
-        window.OneSignal.setExternalUserId(externalUserId)
+        window.OneSignal.push(function () {
+          window.OneSignal.setExternalUserId(externalUserId)
+        })
       }
     },
     optOut () {


### PR DESCRIPTION
Current implementation is outdated and doesn't work.
This change updates web-push-sdk to the latest v7.0 and make it work again.
In summary it now are using push to array instead of calling functions directly.